### PR TITLE
Add PersistentList benchmark

### DIFF
--- a/src/jmh/java/io/github/fourlastor/benchmark/ListsBenchmark.kt
+++ b/src/jmh/java/io/github/fourlastor/benchmark/ListsBenchmark.kt
@@ -1,6 +1,7 @@
 package io.github.fourlastor.benchmark
 
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toPersistentList
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import org.pcollections.TreePVector
@@ -17,9 +18,11 @@ open class ListsBenchmark {
     private val random = Random
     private val list = List(1000) { random.nextInt() }
     private val immutableList = list.toImmutableList()
+    private val persistentList = list.toPersistentList()
     private val pImmutableList = TreePVector.from(list)
     private val smallList = List(100) { random.nextInt() }
     private val smallImmutableList = smallList.toImmutableList()
+    private val smallPersistentList = smallList.toPersistentList()
     private val smallPImmutableList = TreePVector.from(smallList)
 
     private var numberToAdd: Int = 0
@@ -41,6 +44,13 @@ open class ListsBenchmark {
             blackhole.consume(i)
         }
     }
+
+    @Benchmark
+    fun persistentList(blackhole: Blackhole) {
+        for (i in persistentList) {
+            blackhole.consume(i)
+        }
+    }
     @Benchmark
     fun pImmutableList(blackhole: Blackhole) {
         for (i in pImmutableList) {
@@ -50,6 +60,10 @@ open class ListsBenchmark {
     @Benchmark
     fun toImmutableList(blackhole: Blackhole) {
         blackhole.consume(list.toImmutableList())
+    }
+    @Benchmark
+    fun toPersistentList(blackhole: Blackhole) {
+        blackhole.consume(list.toPersistentList())
     }
     @Benchmark
     fun toPImmutableList(blackhole: Blackhole) {
@@ -65,6 +79,10 @@ open class ListsBenchmark {
         blackhole.consume(immutableList + numberToAdd)
     }
     @Benchmark
+    fun persistentListAdd(blackhole: Blackhole) {
+        blackhole.consume(persistentList + numberToAdd)
+    }
+    @Benchmark
     fun pImmutableListAdd(blackhole: Blackhole) {
         blackhole.consume(pImmutableList + numberToAdd)
     }
@@ -75,6 +93,10 @@ open class ListsBenchmark {
     @Benchmark
     fun immutableListConcat(blackhole: Blackhole) {
         blackhole.consume(immutableList + smallImmutableList)
+    }
+    @Benchmark
+    fun persistentListConcat(blackhole: Blackhole) {
+        blackhole.consume(persistentList + smallPersistentList)
     }
     @Benchmark
     fun pImmutableListConcat(blackhole: Blackhole) {


### PR DESCRIPTION
```
Benchmark                             Mode  Cnt        Score   Error  Units
ListsBenchmark.immutableList         thrpt    2   287024.621          ops/s
ListsBenchmark.immutableListAdd      thrpt    2   222454.877          ops/s
ListsBenchmark.immutableListConcat   thrpt    2   191025.812          ops/s
ListsBenchmark.list                  thrpt    2   417106.624          ops/s
ListsBenchmark.listAdd               thrpt    2   929063.889          ops/s
ListsBenchmark.listConcat            thrpt    2   825972.018          ops/s
ListsBenchmark.pImmutableList        thrpt    2    95566.300          ops/s
ListsBenchmark.pImmutableListAdd     thrpt    2  5165650.974          ops/s
ListsBenchmark.pImmutableListConcat  thrpt    2    77653.832          ops/s
ListsBenchmark.persistentList        thrpt    2   285442.642          ops/s
ListsBenchmark.persistentListAdd     thrpt    2   224015.258          ops/s
ListsBenchmark.persistentListConcat  thrpt    2   190583.764          ops/s
ListsBenchmark.toImmutableList       thrpt    2   283350.196          ops/s
ListsBenchmark.toPImmutableList      thrpt    2     6740.635          ops/s
ListsBenchmark.toPersistentList      thrpt    2   285795.422          ops/s
```